### PR TITLE
feat: capture option changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,14 @@
 mod optionscraper;
 mod riskfreerate_lib;
 
-use optionscraper::OptionScraper;
+use chrono::Local;
+use optionscraper::{OptionRow, OptionScraper};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 
 fn main() -> Result<(), String> {
     // Prompt the user for a ticker symbol instead of using a hard-coded value
@@ -20,9 +26,136 @@ fn main() -> Result<(), String> {
     let sc = OptionScraper::new(ticker)?;
     let rows = sc.scrape_data()?;
 
-    // Print all fields for each option row
-    for r in rows.iter() {
-        println!("{:#?}", r);
-    }
+    // Save results and capture changes
+    save_with_change_capture(ticker, &rows)?;
+
     Ok(())
+}
+
+fn save_with_change_capture(ticker: &str, rows: &[OptionRow]) -> Result<(), String> {
+    let out_dir = Path::new("data").join(ticker);
+    fs::create_dir_all(&out_dir).map_err(|e| e.to_string())?;
+
+    // locate previous run before writing new files
+    let prev_file = find_latest_file(&out_dir, ticker);
+
+    // If previous exists, mark it inactive and compute diffs
+    let mut changes: Vec<ChangeRecord> = Vec::new();
+    if let Some(prev_path) = &prev_file {
+        let prev_text = fs::read_to_string(prev_path).map_err(|e| e.to_string())?;
+        let mut prev_rows: Vec<OptionRow> =
+            serde_json::from_str(&prev_text).map_err(|e| e.to_string())?;
+        for r in prev_rows.iter_mut() {
+            r.active = false;
+        }
+        let prev_json = serde_json::to_string_pretty(&prev_rows).map_err(|e| e.to_string())?;
+        fs::write(prev_path, prev_json).map_err(|e| e.to_string())?;
+
+        let prev_map: HashMap<String, OptionRow> = prev_rows
+            .into_iter()
+            .map(|r| (r.option.clone(), r))
+            .collect();
+        let curr_map: HashMap<String, OptionRow> = rows
+            .iter()
+            .cloned()
+            .map(|r| (r.option.clone(), r))
+            .collect();
+        let keys: HashSet<_> = prev_map
+            .keys()
+            .cloned()
+            .chain(curr_map.keys().cloned())
+            .collect();
+        for k in keys {
+            match (prev_map.get(&k), curr_map.get(&k)) {
+                (Some(old), Some(new)) => {
+                    if old != new {
+                        changes.extend(diff_rows(old, new));
+                    }
+                }
+                (None, Some(new)) => {
+                    changes.push(ChangeRecord {
+                        option: k.clone(),
+                        field: "record".to_string(),
+                        old_value: Value::Null,
+                        new_value: serde_json::to_value(new).unwrap_or(Value::Null),
+                        old_active: false,
+                        new_active: true,
+                    });
+                }
+                (Some(old), None) => {
+                    changes.push(ChangeRecord {
+                        option: k.clone(),
+                        field: "record".to_string(),
+                        old_value: serde_json::to_value(old).unwrap_or(Value::Null),
+                        new_value: Value::Null,
+                        old_active: false,
+                        new_active: false,
+                    });
+                }
+                (None, None) => {}
+            }
+        }
+    }
+
+    // write new raw file
+    let ts = Local::now().format("%Y%m%d_%H%M").to_string();
+    let raw_path = out_dir.join(format!("{}_{}.json", ticker, ts));
+    let json = serde_json::to_string_pretty(rows).map_err(|e| e.to_string())?;
+    fs::write(&raw_path, json).map_err(|e| e.to_string())?;
+
+    if !changes.is_empty() {
+        let cdc_path = out_dir.join(format!("{}_{}_cdc.json", ticker, ts));
+        let cdc_json = serde_json::to_string_pretty(&changes).map_err(|e| e.to_string())?;
+        fs::write(cdc_path, cdc_json).map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize)]
+struct ChangeRecord {
+    option: String,
+    field: String,
+    old_value: Value,
+    new_value: Value,
+    old_active: bool,
+    new_active: bool,
+}
+
+fn diff_rows(old: &OptionRow, new: &OptionRow) -> Vec<ChangeRecord> {
+    let old_val = serde_json::to_value(old).unwrap_or(Value::Null);
+    let new_val = serde_json::to_value(new).unwrap_or(Value::Null);
+    let mut diffs = Vec::new();
+    if let (Value::Object(o_map), Value::Object(n_map)) = (old_val, new_val) {
+        for (k, o_v) in o_map.iter() {
+            if let Some(n_v) = n_map.get(k) {
+                if o_v != n_v {
+                    diffs.push(ChangeRecord {
+                        option: new.option.clone(),
+                        field: k.clone(),
+                        old_value: o_v.clone(),
+                        new_value: n_v.clone(),
+                        old_active: false,
+                        new_active: true,
+                    });
+                }
+            }
+        }
+    }
+    diffs
+}
+
+fn find_latest_file(dir: &Path, ticker: &str) -> Option<PathBuf> {
+    fs::read_dir(dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|s| s.starts_with(&format!("{}_", ticker)) && !s.contains("_cdc"))
+                .unwrap_or(false)
+        })
+        .max_by_key(|p| p.file_name().and_then(|n| n.to_str()).map(|s| s.to_owned()))
 }

--- a/src/optionscraper.rs
+++ b/src/optionscraper.rs
@@ -4,6 +4,7 @@ use chrono::{Datelike, Duration as ChronoDuration, NaiveDate, NaiveDateTime, Utc
 use chrono_tz::America::Chicago;
 use regex::Regex;
 use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -421,6 +422,7 @@ impl OptionScraper {
                 spot_price,
                 data_update_time: ts_raw.clone(), // <— clone per row
                 data_update_time_cst: ts_cst.clone(), // <— clone per row
+                active: true,
             });
         }
 
@@ -430,7 +432,7 @@ impl OptionScraper {
 
 // =============== Return row (like a DataFrame row) ===============
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OptionRow {
     pub option: String,
     pub contract_type: String, // "C" or "P"
@@ -480,6 +482,7 @@ pub struct OptionRow {
     pub spot_price: f64,
     pub data_update_time: String,
     pub data_update_time_cst: String,
+    pub active: bool,
 }
 
 // =============== Internal shaping structs ===============


### PR DESCRIPTION
## Summary
- persist scraped option rows to timestamped files
- generate CDC files when changes appear between runs
- mark active option snapshots

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a209f0d8dc8323a84f9737573b9bc7